### PR TITLE
Fix some of the failing tests

### DIFF
--- a/tests/test_genanki.py
+++ b/tests/test_genanki.py
@@ -291,8 +291,8 @@ class TestWithCollection:
 
     self.import_package(genanki.Package(deck))
 
-    assert self.col.findCards('') == [1, 2]
-    assert self.col.findCards('is:suspended') == [2]
+    assert len(self.col.findCards('')) == 2
+    assert len(self.col.findCards('is:suspended')) == 1
 
   def test_deck_with_description(self):
     deck = genanki.Deck(112233, 'foodeck', description='This is my great deck.\nIt is so so great.')

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -26,7 +26,7 @@ def test_ok():
     fields=['Capital of Argentina', 'Buenos Aires'])
 
   with pytest.warns(None) as warn_recorder:
-    my_note.write_to_db(mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
+    my_note.write_to_db(mock.MagicMock(), mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
 
   # Should be no warnings issued.
   assert not warn_recorder
@@ -97,7 +97,7 @@ def test_num_fields_equals_model_ok():
     fields=['What is the capital of Taiwan?', 'Taipei',
             'Taipei was originally inhabitied by the Ketagalan people prior to the arrival of Han settlers in 1709.'])
 
-  n.write_to_db(mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
+  n.write_to_db(mock.MagicMock(), mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
   # test passes if code gets to here without raising
 
 
@@ -121,7 +121,7 @@ def test_num_fields_less_than_model_raises():
   n = genanki.Note(model=m, fields=['What is the capital of Taiwan?', 'Taipei'])
 
   with pytest.raises(ValueError):
-    n.write_to_db(mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
+    n.write_to_db(mock.MagicMock(), mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
 
 
 def test_num_fields_more_than_model_raises():
@@ -146,7 +146,7 @@ def test_num_fields_more_than_model_raises():
             'Taipei was originally inhabitied by the Ketagalan people prior to the arrival of Han settlers in 1709.'])
 
   with pytest.raises(ValueError):
-    n.write_to_db(mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
+    n.write_to_db(mock.MagicMock(), mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
 
 
 class TestFindInvalidHtmlTagsInField:
@@ -224,7 +224,7 @@ def test_warns_on_invalid_html_tags():
     fields=['Capital of <$> Argentina', 'Buenos Aires'])
 
   with pytest.warns(UserWarning, match='^Field contained the following invalid HTML tags.*$'):
-    my_note.write_to_db(mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
+    my_note.write_to_db(mock.MagicMock(), mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
 
 
 def test_suppress_warnings(recwarn):
@@ -249,6 +249,6 @@ def test_suppress_warnings(recwarn):
 
   with pytest.warns(None) as warn_recorder:
     warnings.filterwarnings('ignore', message='^Field contained the following invalid HTML tags', module='genanki')
-    my_note.write_to_db(mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
+    my_note.write_to_db(mock.MagicMock(), mock.MagicMock(), mock.MagicMock(), mock.MagicMock())
 
   assert not warn_recorder


### PR DESCRIPTION
Hei there 👋🏾 

I have started looking into the failures after you rebased, thanks! I have fixed some but are still more outstanding.
Please see the individual commits for the fixes and below is a summary of the outstanding.

### Outstanding 

I have not read your code well, so might be wrong. I think what is happening is that there is some timing issues so you are generating duplicate ids. I tried doing some print debugging and that was the case if you log the, for example

```diff
diff --git a/genanki/note.py b/genanki/note.py
index e474ff2d1737..fff29a60b3c8 100644
--- a/genanki/note.py
+++ b/genanki/note.py
@@ -146,6 +146,7 @@ class Note:
   def write_to_db(self, cursor, now_ts, deck_id, note_idx):
     now_ts_milliseconds = now_ts * 1000
     note_id = now_ts_milliseconds + note_idx
+    print(21, 21, 'write_to_db:', deck_id, '-x-', note_idx, '-x-', note_id)
     self._check_number_model_fields_matches_num_fields()
     self._check_invalid_html_tags_in_fields()
     cursor.execute('INSERT INTO notes VALUES(?,?,?,?,?,?,?,?,?,?,?);', (
```

I then see

```
----------------------------------------------------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------------------------------------------------
21 21 write_to_db: 123456 -x- 0 -x- 1606591805000
21 21 write_to_db: 654321 -x- 0 -x- 1606591805000
=========================================================================================================================== short test summary info ============================================================================================================================
FAILED tests/test_builtin_models.py::test_builtin_models - sqlite3.IntegrityError: UNIQUE constraint failed: cards.id
FAILED tests/test_genanki.py::TestWithCollection::test_multi_deck_package - sqlite3.IntegrityError: UNIQUE constraint failed: notes.id
========================================================================================================================= 2 failed, 44 passed in 0.67s =========================================================================================================================
```